### PR TITLE
create pod-reader in ns-2 before creating rolebinding

### DIFF
--- a/create-roles.md
+++ b/create-roles.md
@@ -52,8 +52,17 @@ namespaces.
     ```sh
     2-kubectl get pods --namespace=ns-2
     ```
-2. Re-use the role that was created.
+2. Create the `pod-reader` role in `ns-2`, and then create a role binding to
+   associate the role with GCP Service Account 2.
+
     ```sh
+    a-kubectl create role pod-reader \
+        --verb=get \
+        --verb=list \
+        --verb=watch \
+        --resource=pods \
+        --namespace=ns-2
+
     a-kubectl create rolebinding account2-pod-reader-binding \
         --role=pod-reader \
         --user=$account2 \


### PR DESCRIPTION
Hey @jcbsmpsn thanks so much for this walkthrough, I have found it very helpful! 

I think I noticed an error in the "Create roles and role bindings" step though, or at least GKE/Kubernetes behavior that may have changed since the walkthrough was created.

At least with cluster version 1.6.4, creating the RoleBinding at this
point in the ns-2 namespace will fail because no Role in that namespace
exists - it is not possible to reuse the role from namespace ns-1.

```
$ a-kubectl create rolebinding account2-pod-reader-binding \
>     --role=pod-reader \
>     --user=$account2 \
>     --namespace=ns-2
rolebinding "account2-pod-reader-binding" created

$ 2-kubectl get pods --namespace=ns-2
Error from server (Forbidden): User "cluster-user-2@cluster-name.iam.gserviceaccount.com" cannot list pods in the namespace "ns-2".: "role.rbac.authorization.k8s.io \"pod-reader\" not found\nRequired \"container.pods.list\" permission." (get pods)
```